### PR TITLE
add attendance sheets collection to the api

### DIFF
--- a/src/api/models/attendance/createAttendance.ts
+++ b/src/api/models/attendance/createAttendance.ts
@@ -1,0 +1,39 @@
+import { Response } from 'express';
+import mongoose from 'mongoose';
+import { IAttendance, IAttendanceDoc } from '../../../mongodb/attendance.db';
+
+const Doc = mongoose.model<IAttendanceDoc>('Attendance Sheets');
+
+async function createAttendance(data: IAttendance, res: Response = null): Promise<IAttendance> {
+  try {
+    // create a new attendance document
+    const { patrol, is_present, uniform_points } = data;
+    const document = new Doc({
+      patrol,
+      is_present,
+      uniform_points,
+      timestamps: {
+        created_at: data.timestamps?.created_at,
+      },
+    });
+
+    // save the new document to the collection
+    await document.save();
+
+    // tell the client we saved it
+    if (res) {
+      res.status(201).end();
+      res.json({ _id: document._id }); // send the _id of the new document
+    }
+
+    // return the new document
+    return document.toObject();
+  } catch (error) {
+    // handle any errors
+    console.error(error);
+    if (res) {
+      res.status(400).end();
+    }
+  }
+}
+export { createAttendance };

--- a/src/api/models/attendance/deleteAttendance.ts
+++ b/src/api/models/attendance/deleteAttendance.ts
@@ -1,0 +1,24 @@
+import { Response } from 'express';
+import mongoose from 'mongoose';
+import { IAttendanceDoc } from '../../../mongodb/attendance.db';
+
+const model = mongoose.model<IAttendanceDoc>('Attendance Sheets');
+
+/**
+ * Delete a attendace document from the attendance sheets database by `id`.
+ * @param id the unique `id` for the patrol
+ */
+async function deleteAttendance(id: string, res: Response = null): Promise<void> {
+  try {
+    // delete a patrol (if it exists)
+    await model.deleteOne({ _id: id });
+
+    // tell the client that the document is gone
+    if (res) res.status(410).end();
+  } catch (error) {
+    // handle any errors
+    console.error(error);
+    if (res) res.status(500).end();
+  }
+}
+export { deleteAttendance };

--- a/src/api/models/attendance/getAttendance.ts
+++ b/src/api/models/attendance/getAttendance.ts
@@ -1,0 +1,26 @@
+import { Response } from 'express';
+import mongoose from 'mongoose';
+import { IAttendanceDoc, IAttendance } from '../../../mongodb/attendance.db';
+
+const Doc = mongoose.model<IAttendanceDoc>('Attendance Sheets');
+
+/**
+ * Get an attendance doucment by _id from the attendance sheets collection.
+ *
+ * @returns an attendance document
+ */
+async function getAttendance(id: string, res: Response = null): Promise<IAttendance> {
+  try {
+    const document = await Doc.findById(id);
+
+    // end the request by sending a response
+    if (res) res.json(document);
+
+    return document.toObject();
+  } catch (error) {
+    console.error(error);
+    if (res) res.status(400).end();
+  }
+}
+
+export { getAttendance };

--- a/src/api/models/attendance/getAttendances.ts
+++ b/src/api/models/attendance/getAttendances.ts
@@ -1,0 +1,55 @@
+import { Response } from 'express';
+import mongoose from 'mongoose';
+import { IAttendanceDoc, IAttendance } from '../../../mongodb/attendance.db';
+import { addDays } from '../../../helpers/addDays';
+
+const Doc = mongoose.model<IAttendanceDoc>('Attendance Sheets');
+
+/**
+ * Get all attendance documents in the attendance sheets collection.
+ *
+ * @param search instance of URLSearchParams
+ * @returns an array of patrols
+ */
+async function getAttendances(search: URLSearchParams, res: Response = null): Promise<IAttendance[]> {
+  try {
+    // get relevant search params
+    const patrol: string | null = search.get('patrol');
+    const date: string | null = search.get('date');
+
+    // create filters
+    const filters = {
+      // if patrol search param is defined, search for attendance documents for that patrol
+      // othwerwise, set the patrolFilter to undefined
+      patrolFilter: patrol ? { patrol: patrol } : undefined,
+      // if date search param is defined, search for attendance documents for around that date (+/- one day)
+      // othwerwise, set the dateFilter to undefined
+      dateFilter: date
+        ? {
+            // find attendance documents where `timestamps.meeting_date` is in the provided range
+            'timestamps.meeting_date': {
+              $gt: addDays(date, -1), // greater than the input date subtracted by one day
+              $lt: addDays(date, 1), // and less that the inpout date added by one day
+            },
+          }
+        : undefined,
+    };
+
+    // get attendance documents that match the provided filter
+    const documents = await Doc.find({ ...filters.patrolFilter, ...filters.dateFilter });
+
+    // end the request by sending a response with the found documents
+    if (res) res.json(documents);
+
+    // return an array of attendance objects
+    // by looping through the array of attendance documents and converting each one to an object
+    return documents.map((document: IAttendanceDoc) => document.toObject());
+  } catch (error) {
+    // log errors to the server console
+    console.error(error);
+    // tell the client that there was an error, and then end the request
+    if (res) res.status(400).end();
+  }
+}
+
+export { getAttendances };

--- a/src/api/models/attendance/index.ts
+++ b/src/api/models/attendance/index.ts
@@ -1,0 +1,5 @@
+export { createAttendance } from './createAttendance';
+export { deleteAttendance } from './deleteAttendance';
+export { getAttendance } from './getAttendance';
+export { getAttendances } from './getAttendances';
+export { updateAttendance } from './updateAttendance';

--- a/src/api/models/attendance/updateAttendance.ts
+++ b/src/api/models/attendance/updateAttendance.ts
@@ -1,0 +1,55 @@
+import { Response } from 'express';
+import mongoose from 'mongoose';
+import { IAttendanceDoc, IAttendance } from '../../../mongodb/attendance.db';
+import { getAttendance } from './getAttendance';
+
+const Doc = mongoose.model<IAttendanceDoc>('Attendance Sheets');
+
+/**
+ * Updates an attendance document with the supplied information.
+ * Also updates the time_modified time stamp.
+ * @param id The unique id of the attendance document to change.
+ * @param data The complete or incomplete attendance document which will supply the new information.
+ * @param histostryType The kind of change you are performing. (Set normally to 'patched.')
+ * @param res The prescribed response from the server.
+ * @returns The modified attendance document.
+ */
+async function updateAttendance(
+  id: string,
+  data: Partial<IAttendance>,
+  histostryType: 'hidden' | 'patched' | 'created' = 'patched',
+  res: Response = null
+): Promise<IAttendance> {
+  try {
+    // processing data
+    const { patrol, is_present, uniform_points } = data;
+    const changedData = {
+      patrol,
+      is_present,
+      uniform_points,
+      timestamps: {
+        // changing the modified_at timestamp
+        ...data.timestamps,
+        modified_at: new Date().toISOString(),
+      },
+    };
+
+    // save the changes and update any remaining differences between data and the patrol
+    await Doc.updateOne({ _id: id }, { $set: changedData });
+
+    // let the server know the change was successful
+    if (res) res.status(200).end();
+
+    // return the modified document
+    return await getAttendance(id);
+  } catch (error) {
+    // handle any errors
+    console.error(error);
+    if (res) {
+      // let the client know the request failed
+      res.status(400).end();
+    }
+  }
+}
+
+export { updateAttendance };

--- a/src/api/routes/attendance.route.ts
+++ b/src/api/routes/attendance.route.ts
@@ -1,0 +1,14 @@
+import { Router, Request, Response } from 'express';
+import { getAttendance, getAttendances, createAttendance, deleteAttendance, updateAttendance } from '../models/attendance';
+
+// define a router to hold all routes related to patrols
+const router = Router();
+
+router.get('/', (req: Request, res: Response) => getAttendances(req.search, res));
+router.get('/:id', (req: Request, res: Response) => getAttendance(req.params.id, res));
+router.post('/', (req: Request, res: Response) => createAttendance(req.body, res));
+router.delete('/:id', (req: Request, res: Response) => deleteAttendance(req.params.id, res));
+router.patch('/:id', (req: Request, res: Response) => updateAttendance(req.params.id, req.body, 'patched', res));
+
+// export the router so that it can be added to the app routes
+export { router as attendanceRouter };

--- a/src/app.ts
+++ b/src/app.ts
@@ -28,4 +28,8 @@ app.get('/', (req, res) => {
 import { patrolsRouter } from './api/routes/patrols.route';
 app.use('/patrols', patrolsRouter);
 
+// add attendance sheets routes
+import { attendanceRouter } from './api/routes/attendance.route';
+app.use('/attendance', attendanceRouter);
+
 export { app };

--- a/src/helpers/addDays.ts
+++ b/src/helpers/addDays.ts
@@ -1,0 +1,7 @@
+function addDays(date: string, days: number) {
+  const result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+}
+
+export { addDays };

--- a/src/mongodb/attendance.db.ts
+++ b/src/mongodb/attendance.db.ts
@@ -7,6 +7,7 @@ interface IAttendance {
   timestamps: {
     created_at: string;
     modified_at: string;
+    meeting_date: string;
   };
 }
 
@@ -26,6 +27,11 @@ const AttendanceSchemaFields: Record<keyof IAttendance, unknown> = {
       type: Date,
       required: true,
       default: new Date().toISOString(),
+    },
+    meeting_date: {
+      type: Date,
+      required: true,
+      default: `${new Date().toISOString().split('T')[0]}T00:00:00.000Z`, // ISO datetime string without meaningful time
     },
   },
 };


### PR DESCRIPTION
This pull request does the following:
- adds functions and routes for GET, POST, PATCH, and DELETE for attendance sheet collection documents (at /attendance)
- updates the database schema to include `timestamps.meeting_date`
- add a helper for manipulating dates